### PR TITLE
Removed need of "uid" attribute in <parameter replace=... />

### DIFF
--- a/Apps/VRRender/rc/configurations/VRRenderBase.xml
+++ b/Apps/VRRender/rc/configurations/VRRenderBase.xml
@@ -101,10 +101,10 @@
         <service uid="dynamicView" type="::guiQt::editor::SDynamicView" autoConnect="yes">
             <mainActivity id="SDBVRRender" closable="false" />
             <parameters>
-                <parameter replace="SERIESDB" uid="seriesDB" />
+                <parameter replace="SERIESDB" by="seriesDB" />
                 <parameter replace="ICON_PATH" by="${appIconPath}" />
-                <parameter replace="DYNAMICVIEW_CHANNEL" uid="dynamicViewChannel" />
-                <parameter replace="PROGRESS_CHANNEL" uid="progressStatus" />
+                <parameter replace="DYNAMICVIEW_CHANNEL" by="dynamicViewChannel" />
+                <parameter replace="PROGRESS_CHANNEL" by="progressStatus" />
             </parameters>
         </service>
 

--- a/Apps/VRRender/rc/configurations/sdb.xml
+++ b/Apps/VRRender/rc/configurations/sdb.xml
@@ -173,7 +173,7 @@
                 <parameters>
                     <parameter replace="ICON_PATH" by="${ICON_PATH}" />
                     <parameter replace="APP_NAME" by="VRRender" />
-                    <parameter replace="PROGRESS_CHANNEL" uid="progressStatus" />
+                    <parameter replace="PROGRESS_CHANNEL" uid="${PROGRESS_CHANNEL}" />
                 </parameters>
                 <filter>
                     <mode>include</mode>
@@ -188,7 +188,7 @@
                 <parameters>
                     <parameter replace="SERIESDB" by="${SERIESDB}"  />
                     <parameter replace="ICON_PATH" by="${ICON_PATH}" />
-                    <parameter replace="PROGRESS_CHANNEL" uid="progressStatus" />
+                    <parameter replace="PROGRESS_CHANNEL" uid="${PROGRESS_CHANNEL}" />
                 </parameters>
                 <filter>
                     <mode>include</mode>

--- a/Apps/VRRender/rc/configurations/sdb.xml
+++ b/Apps/VRRender/rc/configurations/sdb.xml
@@ -89,7 +89,7 @@
                 </config>
                 <config id="3DSimpleConfig2" type="::fwMedData::ModelSeries" />
                 <config id="ActivityCreatorConfig" type="::fwMedData::ActivitySeries">
-                    <parameter replace="SERIESDB" uid="${SERIESDB}" />
+                    <parameter replace="SERIESDB" by="${SERIESDB}" />
                 </config>
             </configs>
         </service>
@@ -97,7 +97,7 @@
             <in key="series" uid="selections" />
             <config>
                 <parameters>
-                    <parameter replace="SERIESDB" uid="${SERIESDB}" />
+                    <parameter replace="SERIESDB" by="${SERIESDB}" />
                     <parameter replace="ICON_PATH" by="${ICON_PATH}" />
                 </parameters>
                 <filter>
@@ -113,7 +113,7 @@
             <in key="series" uid="selections" />
             <config>
                 <parameters>
-                    <parameter replace="SERIESDB" uid="${SERIESDB}" />
+                    <parameter replace="SERIESDB" by="${SERIESDB}" />
                     <parameter replace="ICON_PATH" by="${ICON_PATH}" />
                 </parameters>
                 <filter>
@@ -128,7 +128,7 @@
             <in key="series" uid="selections" />
             <config>
                 <parameters>
-                    <parameter replace="SERIESDB" uid="${SERIESDB}" />
+                    <parameter replace="SERIESDB" by="${SERIESDB}" />
                     <parameter replace="ICON_PATH" by="${ICON_PATH}" />
                 </parameters>
                 <filter>
@@ -142,7 +142,7 @@
             <in key="series" uid="selections" />
             <config>
                 <parameters>
-                    <parameter replace="SERIESDB" uid="${SERIESDB}" />
+                    <parameter replace="SERIESDB" by="${SERIESDB}" />
                     <parameter replace="ICON_PATH" by="${ICON_PATH}" />
                 </parameters>
                 <filter>
@@ -173,7 +173,7 @@
                 <parameters>
                     <parameter replace="ICON_PATH" by="${ICON_PATH}" />
                     <parameter replace="APP_NAME" by="VRRender" />
-                    <parameter replace="PROGRESS_CHANNEL" uid="${PROGRESS_CHANNEL}" />
+                    <parameter replace="PROGRESS_CHANNEL" by="${PROGRESS_CHANNEL}" />
                 </parameters>
                 <filter>
                     <mode>include</mode>
@@ -188,7 +188,7 @@
                 <parameters>
                     <parameter replace="SERIESDB" by="${SERIESDB}"  />
                     <parameter replace="ICON_PATH" by="${ICON_PATH}" />
-                    <parameter replace="PROGRESS_CHANNEL" uid="${PROGRESS_CHANNEL}" />
+                    <parameter replace="PROGRESS_CHANNEL" by="${PROGRESS_CHANNEL}" />
                 </parameters>
                 <filter>
                     <mode>include</mode>

--- a/Bundles/LeafActivity/2DVisualizationActivity2/rc/configurations/2DVisualization.xml
+++ b/Bundles/LeafActivity/2DVisualizationActivity2/rc/configurations/2DVisualization.xml
@@ -80,9 +80,9 @@
             <appConfig id="2DNegato" />
             <inout key="image" uid="${image}" />
             <inout key="landmarks" uid="${landmarks}" />
-            <parameter replace="WID_PARENT" uid="view_negato1" />
-            <parameter replace="CrossTypeChannel" uid="crossTypeChannel" />
-            <parameter replace="PickingChannel" uid="pickerChannel" />
+            <parameter replace="WID_PARENT" by="view_negato1" />
+            <parameter replace="CrossTypeChannel" by="crossTypeChannel" />
+            <parameter replace="PickingChannel" by="pickerChannel" />
             <parameter replace="orientation" by="axial" />
         </service>
 
@@ -90,9 +90,9 @@
             <appConfig id="2DNegato" />
             <inout key="image" uid="${image}" />
             <inout key="landmarks" uid="${landmarks}" />
-            <parameter replace="WID_PARENT" uid="view_negato2" />
-            <parameter replace="CrossTypeChannel" uid="crossTypeChannel" />
-            <parameter replace="PickingChannel" uid="pickerChannel" />
+            <parameter replace="WID_PARENT" by="view_negato2" />
+            <parameter replace="CrossTypeChannel" by="crossTypeChannel" />
+            <parameter replace="PickingChannel" by="pickerChannel" />
             <parameter replace="orientation" by="frontal" />
         </service>
 
@@ -100,9 +100,9 @@
             <appConfig id="2DNegato" />
             <inout key="image" uid="${image}" />
             <inout key="landmarks" uid="${landmarks}" />
-            <parameter replace="WID_PARENT" uid="view_negato3" />
-            <parameter replace="CrossTypeChannel" uid="crossTypeChannel" />
-            <parameter replace="PickingChannel" uid="pickerChannel" />
+            <parameter replace="WID_PARENT" by="view_negato3" />
+            <parameter replace="CrossTypeChannel" by="crossTypeChannel" />
+            <parameter replace="PickingChannel" by="pickerChannel" />
             <parameter replace="orientation" by="sagittal" />
         </service>
 

--- a/Bundles/LeafActivity/2DVisualizationActivity2/rc/plugin.xml
+++ b/Bundles/LeafActivity/2DVisualizationActivity2/rc/plugin.xml
@@ -33,8 +33,8 @@
         <builder>::fwActivities::builder::ActivitySeriesInitData</builder>
         <appConfig id="2DVisualization">
             <parameters>
-                <parameter replace="image" uid="@values.imageSeries.image" />
-                <parameter replace="landmarks" uid="@values.landmarks" />
+                <parameter replace="image" by="@values.imageSeries.image" />
+                <parameter replace="landmarks" by="@values.landmarks" />
             </parameters>
         </appConfig>
     </extension>

--- a/Bundles/LeafActivity/3DVisualizationActivity2/rc/configurations/3DNegatoWithAcq.xml
+++ b/Bundles/LeafActivity/3DVisualizationActivity2/rc/configurations/3DNegatoWithAcq.xml
@@ -11,7 +11,9 @@
         <param name="ModelDisplayChannel" />
         <param name="CrossTypeChannel" default="crossTypeChannel" />
         <param name="PickingChannel" default="pickingChannel" />
-        <param name="Medical3DCamera" />
+        <param name="setSagittalCameraChannel" />
+        <param name="setFrontalCameraChannel" />
+        <param name="setAxialCameraChannel" />
     </parameters>
     <config>
         <object uid="${modelSeries}" type="::fwMedData::ModelSeries" src="ref" />
@@ -85,7 +87,7 @@
                 <adaptor uid="orientationMarker" />
                 <adaptor uid="interactor" />
                 <adaptor uid="pickerInteractor" />
-                <adaptor uid="${Medical3DCamera}" />
+                <adaptor uid="medical3DCamera" />
                 <adaptor uid="MPRNegato" />
                 <adaptor uid="modelSeries" />
                 <adaptor uid="text" />
@@ -111,7 +113,7 @@
             <config renderer="default" picker="negatodefault" event="MOUSE_LEFT_UP" />
         </service>
 
-        <service uid="${Medical3DCamera}" type="::visuVTKAdaptor::SMedical3DCamera">
+        <service uid="medical3DCamera" type="::visuVTKAdaptor::SMedical3DCamera">
             <config renderer="default" sliceIndex="${orientation}" resetAtStart="yes" />
         </service>
 
@@ -194,6 +196,18 @@
             <slot>MPRNegato/setCrossScale</slot>
         </connect>
 
+        <connect channel="${setSagittalCameraChannel}">
+            <slot>medical3DCamera/setSagittal</slot>
+        </connect>
+
+        <connect channel="${setFrontalCameraChannel}">
+            <slot>medical3DCamera/setFrontal</slot>
+        </connect>
+
+        <connect channel="${setAxialCameraChannel}">
+            <slot>medical3DCamera/setAxial</slot>
+        </connect>
+
         <start uid="mainView" />
         <start uid="extractImage" />
         <!-- Deferred -->
@@ -207,7 +221,7 @@
         <start uid="orientationMarker" />
         <start uid="interactor" />
         <start uid="pickerInteractor" />
-        <start uid="${Medical3DCamera}" />
+        <start uid="medical3DCamera" />
         <start uid="MPRNegato" />
         <start uid="modelSeries" />
         <start uid="text" />

--- a/Bundles/LeafActivity/3DVisualizationActivity2/rc/configurations/3DVisualization.xml
+++ b/Bundles/LeafActivity/3DVisualizationActivity2/rc/configurations/3DVisualization.xml
@@ -129,8 +129,8 @@
             <appConfig id="OrganManagerWithSeries" />
             <inout key="ORGAN_MANAGER_MODELSERIES" uid="${modelSeries}" />
             <parameter replace="ICON_PATH" by="${ICON_PATH}" />
-            <parameter replace="ModelRepresentationChannel" uid="ModelRepresentationChannel" />
-            <parameter replace="ModelDisplayChannel" uid="ModelDisplayChannel" />
+            <parameter replace="ModelRepresentationChannel" by="ModelRepresentationChannel" />
+            <parameter replace="ModelDisplayChannel" by="ModelDisplayChannel" />
         </service>
 
         <service uid="cfgNegato1" type="::fwServices::SConfigController">
@@ -139,12 +139,12 @@
             <inout key="modelSeries" uid="${modelSeries}" />
             <inout key="landmarks" uid="${landmarks}" />
             <parameter replace="orientation" by="axial" />
-            <parameter replace="WID_PARENT" uid="view_negato1" />
+            <parameter replace="WID_PARENT" by="view_negato1" />
             <parameter replace="patient_name" by="${patient_name}" />
-            <parameter replace="ModelRepresentationChannel" uid="ModelRepresentationChannel" />
-            <parameter replace="ModelDisplayChannel" uid="ModelDisplayChannel" />
-            <parameter replace="PickingChannel" uid="pickerChannel" />
-            <parameter replace="CrossTypeChannel" uid="crossTypeChannel" />
+            <parameter replace="ModelRepresentationChannel" by="ModelRepresentationChannel" />
+            <parameter replace="ModelDisplayChannel" by="ModelDisplayChannel" />
+            <parameter replace="PickingChannel" by="pickerChannel" />
+            <parameter replace="CrossTypeChannel" by="crossTypeChannel" />
             <parameter replace="setSagittalCameraChannel" by="setSagittalCameraChannel" />
             <parameter replace="setFrontalCameraChannel" by="setFrontalCameraChannel" />
             <parameter replace="setAxialCameraChannel" by="setAxialCameraChannel" />
@@ -178,9 +178,9 @@
             <appConfig id="2DNegato" />
             <inout key="image" uid="optionalInputImage" />
             <inout key="landmarks" uid="${landmarks}" />
-            <parameter replace="WID_PARENT" uid="view_negato2" />
-            <parameter replace="CrossTypeChannel" uid="crossTypeChannel" />
-            <parameter replace="PickingChannel" uid="pickerChannel" />
+            <parameter replace="WID_PARENT" by="view_negato2" />
+            <parameter replace="CrossTypeChannel" by="crossTypeChannel" />
+            <parameter replace="PickingChannel" by="pickerChannel" />
             <parameter replace="orientation" by="frontal" />
             <parameter replace="patient_name" by="${patient_name}" />
         </service>
@@ -189,9 +189,9 @@
             <appConfig id="2DNegato" />
             <inout key="image" uid="optionalInputImage" />
             <inout key="landmarks" uid="${landmarks}" />
-            <parameter replace="WID_PARENT" uid="view_negato3" />
-            <parameter replace="CrossTypeChannel" uid="crossTypeChannel" />
-            <parameter replace="PickingChannel" uid="pickerChannel" />
+            <parameter replace="WID_PARENT" by="view_negato3" />
+            <parameter replace="CrossTypeChannel" by="crossTypeChannel" />
+            <parameter replace="PickingChannel" by="pickerChannel" />
             <parameter replace="orientation" by="sagittal" />
             <parameter replace="patient_name" by="${patient_name}" />
         </service>

--- a/Bundles/LeafActivity/3DVisualizationActivity2/rc/configurations/3DVisualization.xml
+++ b/Bundles/LeafActivity/3DVisualizationActivity2/rc/configurations/3DVisualization.xml
@@ -144,27 +144,15 @@
             <parameter replace="ModelRepresentationChannel" uid="ModelRepresentationChannel" />
             <parameter replace="ModelDisplayChannel" uid="ModelDisplayChannel" />
             <parameter replace="PickingChannel" uid="pickerChannel" />
-            <parameter replace="Medical3DCamera" uid="Medical3DCamera" />
             <parameter replace="CrossTypeChannel" uid="crossTypeChannel" />
+            <parameter replace="setSagittalCameraChannel" by="setSagittalCameraChannel" />
+            <parameter replace="setFrontalCameraChannel" by="setFrontalCameraChannel" />
+            <parameter replace="setAxialCameraChannel" by="setAxialCameraChannel" />
         </service>
 
-        <service uid="action_SagittalViewMPR3D" type="::gui::action::SSlotCaller">
-            <slots>
-                <slot>Medical3DCamera/setSagittal</slot>
-            </slots>
-        </service>
-
-        <service uid="action_FrontalViewMPR3D" type="::gui::action::SSlotCaller">
-            <slots>
-                <slot>Medical3DCamera/setFrontal</slot>
-            </slots>
-        </service>
-
-        <service uid="action_AxialViewMPR3D" type="::gui::action::SSlotCaller">
-            <slots>
-                <slot>Medical3DCamera/setAxial</slot>
-            </slots>
-        </service>
+        <service uid="action_SagittalViewMPR3D" type="::gui::action::SSignal" />
+        <service uid="action_FrontalViewMPR3D" type="::gui::action::SSignal" />
+        <service uid="action_AxialViewMPR3D" type="::gui::action::SSignal" />
 
         <!-- Negato -->
 
@@ -291,6 +279,22 @@
         <connect channel="pickerChannel">
             <slot>landmarksEditor/addPickedPoint</slot>
         </connect>
+
+        <connect channel="setSagittalCameraChannel">
+            <signal>action_SagittalViewMPR3D/triggered</signal>
+        </connect>
+
+        <connect channel="setFrontalCameraChannel">
+            <signal>action_FrontalViewMPR3D/triggered</signal>
+        </connect>
+
+        <connect channel="setAxialCameraChannel">
+            <signal>action_AxialViewMPR3D/triggered</signal>
+        </connect>
+
+        <!-- Shared channels between 3DNegatoWithAcq and OrganManagerWithSeries -->
+        <connect channel="ModelDisplayChannel" />
+        <connect channel="ModelRepresentationChannel" />
 
         <!-- START AND STOP SERVICES -->
         <start uid="mainView" />

--- a/Bundles/LeafActivity/3DVisualizationActivity2/rc/plugin.xml
+++ b/Bundles/LeafActivity/3DVisualizationActivity2/rc/plugin.xml
@@ -31,9 +31,9 @@
         <builder>::fwActivities::builder::ActivitySeriesInitData</builder>
         <appConfig id="3DVisualization">
             <parameters>
-                <parameter replace="imageComposite" uid="@values.imageSeries" />
-                <parameter replace="modelSeries" uid="@values.modelSeries" />
-                <parameter replace="landmarks" uid="@values.landmarks" />
+                <parameter replace="imageComposite" by="@values.imageSeries" />
+                <parameter replace="modelSeries" by="@values.modelSeries" />
+                <parameter replace="landmarks" by="@values.landmarks" />
                 <parameter replace="orientation" by="frontal" />
             </parameters>
         </appConfig>

--- a/Bundles/LeafActivity/blendActivity/rc/configurations/Blend.xml
+++ b/Bundles/LeafActivity/blendActivity/rc/configurations/Blend.xml
@@ -73,7 +73,7 @@
             <inout key="backgroundImageUid" uid="${backgroundImageUid}" />
             <inout key="frontImageUid" uid="${frontImageUid}" />
             <appConfig id="ImageMix" />
-            <parameter replace="WID_PARENT" uid="subView" />
+            <parameter replace="WID_PARENT" by="subView" />
             <parameter replace="SELECTED_TF_KEYA" by="tfBackgroundImage" />
             <parameter replace="SELECTED_TF_KEYB" by="tfFrontImage" />
         </service>
@@ -82,7 +82,7 @@
             <inout key="myImage" uid="${backgroundImageUid}" />
             <inout key="TF_COMPOSITE_ID" uid="TFComposite" />
             <appConfig id="TransferFunctionEditor" />
-            <parameter replace="WID_PARENT" uid="subView" />
+            <parameter replace="WID_PARENT" by="subView" />
             <parameter replace="SELECTED_TF_KEY" by="tfBackgroundImage" />
         </service>
 
@@ -90,7 +90,7 @@
             <inout key="TF_COMPOSITE_ID" uid="TFComposite" />
             <inout key="myImage" uid="${frontImageUid}" />
             <appConfig id="TransferFunctionEditor" />
-            <parameter replace="WID_PARENT" uid="subView" />
+            <parameter replace="WID_PARENT" by="subView" />
             <parameter replace="SELECTED_TF_KEY" by="tfFrontImage" />
         </service>
 

--- a/Bundles/LeafActivity/blendActivity/rc/configurations/TransferFunctionEditor.xml
+++ b/Bundles/LeafActivity/blendActivity/rc/configurations/TransferFunctionEditor.xml
@@ -125,7 +125,7 @@
             <inout key="image" uid="${myImage}" />
             <inout key="histogram" uid="Histogram" />
             <inout key="TFSelections" uid="${TF_COMPOSITE_ID}" />
-            <parameter replace="WID_PARENT" uid="tfWidget" />
+            <parameter replace="WID_PARENT" by="tfWidget" />
             <parameter replace="SelectedTFKey" by="${SELECTED_TF_KEY}" />
         </service>
 

--- a/Bundles/LeafActivity/dicomPacsReaderActivity/rc/configurations/DicomPacsReader.xml
+++ b/Bundles/LeafActivity/dicomPacsReaderActivity/rc/configurations/DicomPacsReader.xml
@@ -152,7 +152,7 @@
             <parentView wid="pacsPreview" />
             <configs>
                 <config id="2DPacsPreviewConfig" type="::fwMedData::DicomSeries" >
-                    <parameter replace="PACS_CONFIGURATION" uid="pacsConfiguration" />
+                    <parameter replace="PACS_CONFIGURATION" by="pacsConfiguration" />
                 </config>
             </configs>
         </service>

--- a/Bundles/LeafActivity/volumeRenderingActivity2/rc/configurations/VolumeRendering.xml
+++ b/Bundles/LeafActivity/volumeRenderingActivity2/rc/configurations/VolumeRendering.xml
@@ -108,8 +108,8 @@
             <appConfig id="OrganManagerWithSeries" />
             <inout key="ORGAN_MANAGER_MODELSERIES" uid="optionalModelSeries" />
             <parameter replace="ICON_PATH" by="${ICON_PATH}" />
-            <parameter replace="ModelRepresentationChannel" uid="ModelRepresentationChannel" />
-            <parameter replace="ModelDisplayChannel" uid="ModelDisplayChannel" />
+            <parameter replace="ModelRepresentationChannel" by="ModelRepresentationChannel" />
+            <parameter replace="ModelDisplayChannel" by="ModelDisplayChannel" />
         </service>
 
         <service uid="ActionSnapshotVR" type="::uiVisu::action::SSnapshot" />
@@ -206,7 +206,7 @@
             <inout key="histogram" uid="Histogram" />
             <inout key="landmarks" uid="landmarks" />
             <inout key="TFSelections" uid="TFSelections" />
-            <parameter replace="WID_PARENT" uid="tfEditor" />
+            <parameter replace="WID_PARENT" by="tfEditor" />
             <parameter replace="SelectedTFKey" by="SelectedTF" />
         </service>
 

--- a/Bundles/LeafActivity/volumeRenderingActivity2/rc/plugin.xml
+++ b/Bundles/LeafActivity/volumeRenderingActivity2/rc/plugin.xml
@@ -28,8 +28,8 @@
         <builder>::fwActivities::builder::ActivitySeries</builder>
         <appConfig id="VolumeRendering">
             <parameters>
-                <parameter replace="image" uid="@values.imageSeries.image" />
-                <parameter replace="optionalModelSeriesComposite" uid="@values.modelSeries" />
+                <parameter replace="image" by="@values.imageSeries.image" />
+                <parameter replace="optionalModelSeriesComposite" by="@values.modelSeries" />
             </parameters>
         </appConfig>
     </extension>

--- a/Bundles/LeafConfig/imageConfig/rc/configurations/TransferFunctionWithNegatoEditor.xml
+++ b/Bundles/LeafConfig/imageConfig/rc/configurations/TransferFunctionWithNegatoEditor.xml
@@ -69,7 +69,7 @@
             <inout key="image" uid="${image}" />
             <inout key="TFSelections" uid="${TFSelections}" />
             <inout key="landmarks" uid="${landmarks}" />
-            <parameter replace="WID_PARENT" uid="negatoView" />
+            <parameter replace="WID_PARENT" by="negatoView" />
             <parameter replace="selectedTFKey" by="${SelectedTFKey}" />
         </service>
 
@@ -78,7 +78,7 @@
             <inout key="image" uid="${image}"/>
             <inout key="histogram" uid="${histogram}"/>
             <inout key="TFSelections" uid="${TFSelections}" />
-            <parameter replace="WID_PARENT" uid="tfScene"/>
+            <parameter replace="WID_PARENT" by="tfScene"/>
             <parameter replace="SelectedTFKey" by="${SelectedTFKey}" />
         </service>
 

--- a/Bundles/core/gui/include/gui/action/SConfigLauncher.hpp
+++ b/Bundles/core/gui/include/gui/action/SConfigLauncher.hpp
@@ -27,30 +27,32 @@ namespace gui
 namespace action
 {
 
-
 /**
- * @brief   To manage configuration file defines in xml extension.
+ * @brief   This action starts/stops a template configuration.
  *
- * This action works on a ::fwData::Composite. It action starts/stops an AppConfig given by its identifier in this action configuration.
- *  - You can specified pattern to replace in the template configuration by the tag 'replace'.
- *  - You can specified pattern to replace by the uid of the object contained by the composite with the given key
- *  - The pattern GENERIC_UID is replaced by a generated unique identifier when the configuration is launch.
- *  This assure that the created object and services in the configuration have a unique uid even if this
- *  configuration is launch several times.
+ *  The parameters of the template configuration <param name="..." /> are filled according to the
+ *  <inout> and <parameter> tags. Using <inout> is especially useful to wait for deferred objects, but it is strongly
+ * recommended to use it to pass any object.
+ * Note that <in> is not supported. This would have no meaning, because we can't ensure the object won't be modified
+ * in the configuration. <out> is also not supported because if we assume that the target configuration produces the
+ * object, thus we would not get a valid id for the matching parameter.
  *
- * Example of this service configuration
+ * @section XML XML Configuration
+ *
  * @code{.xml}
-   <service impl="::gui::action::SConfigLauncher" type="::fwGui::IActionSrv">
-        <config>
-            <appConfig id="Visu2DID" >
-                <parameters>
-                    <parameter replace="SERIESDB" by="medicalData"  />
-                    <parameter replace="IMAGE" by="@values.image"  />
-                </parameters>
-            </appConfig>
-        </config>
-   </service>
+        <service type="::fwServices::SConfigController" >
+            <appConfig id="IdOfConfig" />
+            <inout key="object" uid="..." />
+            <parameter replace="channel" by="changeValueChannel"  />
+            <parameter replace="service" by="serviceUid" />
+        </service>
    @endcode
+ * @subsection In-Out In-Out:
+ * - \b object [::fwData::Object]: \b key specifies the name of the parameter in the target configuration and \b uid
+ * identifies the object whose uid is passed as value of the parameter.
+ * @subsection Configuration Configuration:
+ * - \b parameter: \b replace specifies the name of the parameter in the target configuration and \b by the value of
+ * this parameter. The variable GENERIC_UID can be used as unique identifier when the configuration is launched.
  */
 class GUI_CLASS_API SConfigLauncher : public ::fwGui::IActionSrv
 {

--- a/Bundles/core/gui/include/gui/action/SConfigLauncher.hpp
+++ b/Bundles/core/gui/include/gui/action/SConfigLauncher.hpp
@@ -29,9 +29,7 @@ namespace action
 
 
 /**
- * @class   SConfigLauncher
  * @brief   To manage configuration file defines in xml extension.
- * @date    2013.
  *
  * This action works on a ::fwData::Composite. It action starts/stops an AppConfig given by its identifier in this action configuration.
  *  - You can specified pattern to replace in the template configuration by the tag 'replace'.
@@ -124,7 +122,7 @@ protected:
     virtual void configuring();
 
     /// Overrides
-    virtual void info( std::ostream &_sstream );
+    virtual void info( std::ostream& _sstream );
 
     /**
      * @name Slots
@@ -139,7 +137,7 @@ protected:
      * @}
      */
 
-    ::fwServices::helper::ConfigLauncher::sptr m_configLauncher;
+    ::fwServices::helper::ConfigLauncher::uptr m_configLauncher;
     std::string m_proxychannel; ///< Name of the channel used to connect stopConfig slot to the config frame closing.
 };
 

--- a/Bundles/core/gui/include/gui/action/SSignal.hpp
+++ b/Bundles/core/gui/include/gui/action/SSignal.hpp
@@ -1,5 +1,5 @@
 /* ***** BEGIN LICENSE BLOCK *****
- * FW4SPL - Copyright (C) IRCAD, 2009-2016.
+ * FW4SPL - Copyright (C) IRCAD, 2009-2017.
  * Distributed under the terms of the GNU Lesser General Public License (LGPL) as
  * published by the Free Software Foundation.
  * ****** END LICENSE BLOCK ****** */
@@ -9,15 +9,7 @@
 
 #include "gui/config.hpp"
 
-#include <fwCom/HasSignals.hpp>
-#include <fwCom/Signal.hpp>
-#include <fwCom/Slots.hpp>
-
 #include <fwGui/IActionSrv.hpp>
-
-#include <fwServices/IService.hpp>
-
-#include <vector>
 
 namespace gui
 {
@@ -25,18 +17,20 @@ namespace action
 {
 
 /**
- * @brief   Simple Signal service
+ * @brief   Action that sends a signal when it is triggered
  *
- * Triggers a signal when the action is triggered.
- * If the action uses a confirmation, different signals are emitted depending on the confirmation result.
+ * @section Signals Signals
+ * - \b triggered(bool) : Emitted when the action is triggered, with the state of the action as parameter.
+ * - \b cancelled(bool) : Emitted when the user cancel the action, if confirmation has been set up in the configuration.
+ *
+ * @section XML XML Configuration
  *
  * @code{.xml}
-       <service uid="..." type="::gui::action::SSignal" />
+        <service type="::gui::action::SSignal" />
    @endcode
  *
- * See also ::fwGui::IActionSrv::configuring for more configuration parameters.
- * @see IActionSrv::configuring
- *
+ * See also ::fwGui::IActionSrv::initialize for more configuration parameters.
+ * @see IActionSrv::initialize
  */
 
 class GUI_CLASS_API SSignal : public ::fwGui::IActionSrv
@@ -44,16 +38,11 @@ class GUI_CLASS_API SSignal : public ::fwGui::IActionSrv
 
 public:
 
-    typedef std::vector< ::fwData::Object::sptr > ObjectVectorType;
-
-    fwCoreServiceClassDefinitionsMacro ( (SSignal)(::fwGui::IActionSrv) );
+    fwCoreServiceClassDefinitionsMacro( (SSignal)(::fwGui::IActionSrv) );
     typedef ::fwRuntime::ConfigurationElement::sptr ConfigurationType;
 
     /// Type of triggered signal
-    typedef ::fwCom::Signal< void (ObjectVectorType) > TrigerredSignalType;
-
-    /// Type of setObject slot
-    typedef ::fwCom::Slot< void ( ObjectVectorType ) >  SetObjectsSlotType;
+    typedef ::fwCom::Signal< void (bool) > TriggeredSignalType;
 
     /**
      * @brief Constructor. Do nothing.
@@ -67,49 +56,29 @@ public:
 
 protected:
 
-    /**
-     * @brief This method gives information about the class. Do nothing.
-     */
-    GUI_API virtual void info(std::ostream& _sstream );
+    /// Configures the service
+    GUI_API void configuring() override;
 
-    /**
-     * @brief This method emit a signal.
-     */
-    GUI_API void updating();
+    /// Register the action and check if the action is executable.
+    GUI_API virtual void starting() override;
 
-    /**
-     * @brief Configures the service
-     */
-    GUI_API void configuring();
+    /// Unregister the action.
+    GUI_API virtual void stopping() override;
 
-    GUI_API virtual void starting();
+    /// Emit the signal
+    GUI_API void updating() override;
 
-    GUI_API virtual void stopping();
+    /// Give information about the class. Do nothing.
+    GUI_API virtual void info(std::ostream& _sstream ) override;
 
-    /**
-     * @brief setObjects slot's method
-     */
-    virtual void setObjects( ObjectVectorType objects )
-    {
-        m_objects = objects;
-    }
-
-    ///Signal trigerred when action has been trigerred
-    SPTR(TrigerredSignalType) m_sigTriggered;
-    ///Signal trigerred when action has been cancelled
-    SPTR(TrigerredSignalType) m_sigCancelled;
-
-    /// setObject slot : save a vector of objects
-    SPTR(SetObjectsSlotType) m_slotSetObjects;
-
-    /// vector of objects passed to triggered signals
-    ObjectVectorType m_objects;
-
+    /// Signal trigerred when action has been triggered
+    SPTR(TriggeredSignalType) m_sigTriggered;
+    /// Signal trigerred when action has been cancelled
+    SPTR(TriggeredSignalType) m_sigCancelled;
 };
 
 } // namespace action
 } // namespace gui
-
 
 #endif /* __GUI_ACTION_SSIGNAL_HPP__ */
 

--- a/Bundles/core/gui/src/gui/action/SConfigLauncher.cpp
+++ b/Bundles/core/gui/src/gui/action/SConfigLauncher.cpp
@@ -6,20 +6,13 @@
 
 #include "gui/action/SConfigLauncher.hpp"
 
-#include <fwCom/Signal.hpp>
 #include <fwCom/Signal.hxx>
-#include <fwCom/Slot.hpp>
-#include <fwCom/Slot.hxx>
-#include <fwCom/Slots.hpp>
 #include <fwCom/Slots.hxx>
 
-#include <fwRuntime/Convert.hpp>
-
 #include <fwServices/macros.hpp>
-#include <fwServices/registry/AppConfig.hpp>
 #include <fwServices/registry/Proxy.hpp>
 
-#include <fwTools/fwID.hpp>
+#include <boost/make_unique.hpp>
 
 namespace gui
 {
@@ -41,7 +34,7 @@ static const std::string s_CLOSE_CONFIG_CHANNEL_ID = "CLOSE_CONFIG_CHANNEL";
 
 SConfigLauncher::SConfigLauncher() noexcept
 {
-    m_configLauncher = ::fwServices::helper::ConfigLauncher::New();
+    m_configLauncher = ::boost::make_unique< ::fwServices::helper::ConfigLauncher>();
 
     m_sigLaunched = newSignal<LaunchedSignalType>(s_LAUNCHED_SIG);
 
@@ -82,70 +75,7 @@ void SConfigLauncher::configuring()
 {
     this->initialize();
 
-    if(this->isVersion2())
-    {
-        typedef ::fwRuntime::ConfigurationElement::sptr ConfigType;
-        typedef ::fwRuntime::EConfigurationElement::sptr EditableConfigType;
-
-        ConfigType cfg = this->getConfiguration();
-
-        ConfigType appCfg = cfg->findConfigurationElement("appConfig");
-        SLM_ASSERT("Missing 'appConfig' tag.", appCfg);
-        std::string appCfgId = appCfg->getAttributeValue("id");
-
-
-        EditableConfigType srvCfg    = ::fwRuntime::EConfigurationElement::New( "service" );
-        EditableConfigType newCfg    = srvCfg->addConfigurationElement("config");
-        EditableConfigType newAppCfg = newCfg->addConfigurationElement("appConfig");
-        newAppCfg->setAttributeValue("id", appCfgId);
-
-        EditableConfigType newParamsCfg = newAppCfg->addConfigurationElement("parameters");
-
-        const std::vector< ConfigType > inoutsCfg = cfg->find("inout");
-        for (const auto& inoutCfg : inoutsCfg)
-        {
-            std::string key = inoutCfg->getAttributeValue("key");
-            SLM_ASSERT("[" + appCfgId + "] Missing 'key' tag.", !key.empty());
-
-            std::string uid = inoutCfg->getAttributeValue("uid");
-            SLM_ASSERT("[" + appCfgId + "] Missing 'uid' tag.", !uid.empty());
-
-            EditableConfigType newParamCfg = newParamsCfg->addConfigurationElement("parameter");
-            newParamCfg->setAttributeValue("replace", key);
-
-            auto obj = this->getInOut< ::fwData::Object>(key);
-            newParamCfg->setAttributeValue("uid", obj->getID());
-        }
-
-        const std::vector< ConfigType > paramsCfg = cfg->find("parameter");
-        for (const auto& paramCfg : paramsCfg)
-        {
-            std::string replace = paramCfg->getAttributeValue("replace");
-            SLM_ASSERT("[" + appCfgId + "] Missing 'replace' tag.", !replace.empty());
-
-            EditableConfigType newParamCfg = newParamsCfg->addConfigurationElement("parameter");
-            newParamCfg->setAttributeValue("replace", replace);
-
-            std::string uid = paramCfg->getAttributeValue("uid");
-            if(!uid.empty())
-            {
-                newParamCfg->setAttributeValue("uid", uid);
-            }
-            else
-            {
-                std::string by = paramCfg->getAttributeValue("by");
-                SLM_ASSERT("[" + appCfgId + "] Missing 'uid' or 'by' tag.", !by.empty());
-
-                newParamCfg->setAttributeValue("by", by);
-            }
-        }
-
-        m_configLauncher->parseConfig(::fwRuntime::Convert::toPropertyTree(srvCfg));
-    }
-    else
-    {
-        m_configLauncher->parseConfig(this->getConfigTree());
-    }
+    m_configLauncher->parseConfig(this->getConfigTree(), this->getSptr());
 }
 
 //-----------------------------------------------------------------------------

--- a/Bundles/core/gui/src/gui/action/SSignal.cpp
+++ b/Bundles/core/gui/src/gui/action/SSignal.cpp
@@ -1,5 +1,5 @@
 /* ***** BEGIN LICENSE BLOCK *****
- * FW4SPL - Copyright (C) IRCAD, 2009-2016.
+ * FW4SPL - Copyright (C) IRCAD, 2009-2017.
  * Distributed under the terms of the GNU Lesser General Public License (LGPL) as
  * published by the Free Software Foundation.
  * ****** END LICENSE BLOCK ****** */
@@ -7,48 +7,31 @@
 #include "gui/action/SSignal.hpp"
 
 #include <fwCom/Signal.hxx>
-#include <fwCom/Slots.hxx>
-
-#include <fwCore/base.hpp>
 
 #include <fwGui/dialog/MessageDialog.hpp>
 
-#include <fwRuntime/Extension.hpp>
-#include <fwRuntime/helper.hpp>
-
 #include <fwServices/macros.hpp>
-
-#include <fwTools/fwID.hpp>
 
 namespace gui
 {
 namespace action
 {
 
-fwServicesRegisterMacro( ::fwGui::IActionSrv, ::gui::action::SSignal, ::fwData::Object );
+//-----------------------------------------------------------------------------
 
+fwServicesRegisterMacro( ::fwGui::IActionSrv, ::gui::action::SSignal );
 
-static const ::fwCom::Signals::SignalKeyType TRIGERRED_SIG   = "triggered";
-static const ::fwCom::Signals::SignalKeyType CANCELLED_SIG   = "cancelled";
-static const ::fwCom::Signals::SignalKeyType SET_OBJECT_SLOT = "setObjects";
+static const ::fwCom::Signals::SignalKeyType s_TRIGGERED_SIG = "triggered";
+static const ::fwCom::Signals::SignalKeyType s_CANCELLED_SIG = "cancelled";
 
 //-----------------------------------------------------------------------------
 
 SSignal::SSignal() noexcept :
-    m_sigTriggered(TrigerredSignalType::New()),
-    m_sigCancelled(TrigerredSignalType::New()),
-    m_slotSetObjects(SSignal::SetObjectsSlotType::New(&SSignal::setObjects, this))
+    m_sigTriggered(TriggeredSignalType::New()),
+    m_sigCancelled(TriggeredSignalType::New())
 {
-    ::fwCom::HasSignals::m_signals
-        ( TRIGERRED_SIG, m_sigTriggered )
-        ( CANCELLED_SIG, m_sigCancelled );
-
-    ::fwCom::HasSlots::m_slots
-        ( SET_OBJECT_SLOT, m_slotSetObjects );
-
-
-
-    this->setWorker( m_associatedWorker );
+    m_sigTriggered = newSignal<TriggeredSignalType>(s_TRIGGERED_SIG);
+    m_sigCancelled = newSignal<TriggeredSignalType>(s_CANCELLED_SIG);
 }
 
 //-----------------------------------------------------------------------------
@@ -59,9 +42,15 @@ SSignal::~SSignal() noexcept
 
 //-----------------------------------------------------------------------------
 
+void SSignal::configuring()
+{
+    this->initialize();
+}
+
+//-----------------------------------------------------------------------------
+
 void SSignal::starting()
 {
-    SLM_TRACE_FUNC();
     this->actionServiceStarting();
 }
 
@@ -69,16 +58,12 @@ void SSignal::starting()
 
 void SSignal::stopping()
 {
-    SLM_TRACE_FUNC();
-
-    m_objects.clear();
-
     this->actionServiceStopping();
 }
 
 //-----------------------------------------------------------------------------
 
-void SSignal::info(std::ostream &_sstream )
+void SSignal::info(std::ostream& _sstream )
 {
     _sstream << "Starter Action" << std::endl;
 }
@@ -90,22 +75,16 @@ void SSignal::updating()
     SLM_TRACE_FUNC();
     if (this->confirmAction())
     {
-        m_sigTriggered->asyncEmit(m_objects);
+        m_sigTriggered->asyncEmit(this->getIsActive());
     }
     else
     {
-        m_sigCancelled->asyncEmit(m_objects);
+        m_sigCancelled->asyncEmit(this->getIsActive());
     }
 
 }
 
 //-----------------------------------------------------------------------------
-
-void SSignal::configuring()
-{
-    SLM_TRACE_FUNC();
-    this->initialize();
-}
 
 } // namespace action
 } // namespace gui

--- a/Bundles/core/servicesReg/rc/plugin.xml
+++ b/Bundles/core/servicesReg/rc/plugin.xml
@@ -3,14 +3,14 @@
     <library name="servicesReg" />
 
     <requirement id="dataReg" />
-    
+
     <!-- EXTENSION POINT FOR AN APP CONFIGURATION -->
     <extension-point id="::fwServices::registry::AppConfig" schema="appConfig.xsd"/>
     <extension-point id="::fwServices::registry::AppConfig2" schema="appConfig2.xsd"/>
-    
+
     <!-- EXTENSION POINT FOR APP CONFIGURATION PARAMETERS-->
     <extension-point id="::fwServices::registry::AppConfigParameters" schema="appConfigParameters.xsd"/>
-    
+
     <!-- EXTENSION POINT FOR A SERVICE FACTORY -->
     <extension-point id="::fwServices::registry::ServiceFactory" schema="serviceFactory.xsd"/>
 
@@ -23,7 +23,7 @@
         <service>::dataReg::parser::Composite</service>
         <object>::fwData::Composite</object>
     </extension>
-    
+
     <extension implements="::fwServices::registry::ServiceFactory">
         <type>::fwServices::IXMLParser</type>
         <service>::dataReg::parser::TransformationMatrix3D</service>
@@ -35,47 +35,46 @@
         <service>::dataReg::parser::Object</service>
         <object>::fwData::Object</object>
     </extension>
-    
+
      <extension implements="::fwServices::registry::ServiceFactory">
         <type>::fwServices::IXMLParser</type>
         <service>::dataReg::parser::List</service>
         <object>::fwData::List</object>
     </extension>
-    
+
     <extension implements="::fwServices::registry::ServiceFactory">
         <type>::fwServices::IXMLParser</type>
         <service>::dataReg::parser::BooleanParser</service>
         <object>::fwData::Boolean</object>
     </extension>
-    
+
     <extension implements="::fwServices::registry::ServiceFactory">
         <type>::fwServices::IXMLParser</type>
         <service>::dataReg::parser::FloatParser</service>
         <object>::fwData::Float</object>
     </extension>
-    
+
      <extension implements="::fwServices::registry::ServiceFactory">
         <type>::fwServices::IXMLParser</type>
         <service>::dataReg::parser::IntegerParser</service>
         <object>::fwData::Integer</object>
     </extension>
-    
+
      <extension implements="::fwServices::registry::ServiceFactory">
         <type>::fwServices::IXMLParser</type>
         <service>::dataReg::parser::StringParser</service>
         <object>::fwData::String</object>
     </extension>
-     
+
      <extension implements="::fwServices::registry::ServiceFactory">
         <type>::fwServices::IXMLParser</type>
         <service>::dataReg::parser::TransferFunction</service>
         <object>::fwData::TransferFunction</object>
     </extension>
-     
+
     <extension implements="::fwServices::registry::ServiceFactory">
         <type>::fwServices::IController</type>
         <service>::fwServices::SConfigController</service>
-        <object>::fwData::Object</object>
     </extension>
-    
+
 </plugin>

--- a/Samples/Examples/Ex01VolumeRendering/rc/plugin.xml
+++ b/Samples/Examples/Ex01VolumeRendering/rc/plugin.xml
@@ -442,9 +442,9 @@ Comment: Name inside the drawing are the uid of the service defined below.
 
             <service uid="imageEditorsManager" type="::fwServices::SConfigController">
                 <appConfig id="ImageManager" />
-                <parameter replace="WID_PARENT" uid="multiView_scene1_editors" />
-                <parameter replace="IMAGE_UID" uid="imageUID" />
-                <parameter replace="TF_IMAGE" uid="TFSelectionsUID" />
+                <parameter replace="WID_PARENT" by="multiView_scene1_editors" />
+                <parameter replace="IMAGE_UID" by="imageUID" />
+                <parameter replace="TF_IMAGE" by="TFSelectionsUID" />
                 <parameter replace="TF_KEY" by="SelectedTF" />
             </service>
 

--- a/Samples/Examples/Ex05Activities/rc/configurations/Ex05Base.xml
+++ b/Samples/Examples/Ex05Activities/rc/configurations/Ex05Base.xml
@@ -85,7 +85,6 @@
             <parameters>
                 <parameter replace="SERIESDB" uid="seriesDB" />
                 <parameter replace="ICON_PATH" by="${appIconPath}" />
-                <parameter replace="PARAMETERS_CHANNEL" uid="parametersChannel" />
                 <parameter replace="enabledPreviousChannel" uid="enabledPreviousChannel" />
                 <parameter replace="enabledNextChannel" uid="enabledNextChannel" />
                 <parameter replace="previousActivityChannel" uid="previousActivityChannel" />

--- a/Samples/Examples/Ex05Activities/rc/configurations/Ex05Base.xml
+++ b/Samples/Examples/Ex05Activities/rc/configurations/Ex05Base.xml
@@ -83,12 +83,12 @@
         <!-- Display the activity in the current view -->
         <service uid="dynamicView" type="::guiQt::editor::SActivityView">
             <parameters>
-                <parameter replace="SERIESDB" uid="seriesDB" />
+                <parameter replace="SERIESDB" by="seriesDB" />
                 <parameter replace="ICON_PATH" by="${appIconPath}" />
-                <parameter replace="enabledPreviousChannel" uid="enabledPreviousChannel" />
-                <parameter replace="enabledNextChannel" uid="enabledNextChannel" />
-                <parameter replace="previousActivityChannel" uid="previousActivityChannel" />
-                <parameter replace="nextActivityChannel" uid="nextActivityChannel" />
+                <parameter replace="enabledPreviousChannel" by="enabledPreviousChannel" />
+                <parameter replace="enabledNextChannel" by="enabledNextChannel" />
+                <parameter replace="previousActivityChannel" by="previousActivityChannel" />
+                <parameter replace="nextActivityChannel" by="nextActivityChannel" />
             </parameters>
         </service>
 

--- a/Samples/Examples/Ex05Activities/rc/configurations/Ex05ImageDisplaying.xml
+++ b/Samples/Examples/Ex05Activities/rc/configurations/Ex05ImageDisplaying.xml
@@ -27,7 +27,7 @@
             <inout key="AS_UID" uid="${AS_UID}" />
             <inout key="image" uid="${image}" />
             <inout key="landmarks" uid="${landmarks}" />
-            <parameter replace="WID_PARENT" uid="${WID_PARENT}" />
+            <parameter replace="WID_PARENT" by="${WID_PARENT}" />
             <parameter replace="enabledPreviousChannel" by="${enabledPreviousChannel}" />
             <parameter replace="previousActivityChannel" by="${previousActivityChannel}" />
             <parameter replace="enabledNextChannel" by="${enabledNextChannel}" />

--- a/SrcLib/core/fwActivities/src/fwActivities/registry/Activities.cpp
+++ b/SrcLib/core/fwActivities/src/fwActivities/registry/Activities.cpp
@@ -25,6 +25,8 @@ namespace registry
 ActivityAppConfigParam::ActivityAppConfigParam(const ConfigType &config) :
     replace(config.get<std::string>("<xmlattr>.replace"))
 {
+    // @deprecated This is no longer necessary to use "uid" to get the prefix replacement, since
+    // this is now done in AppConfig2. However we keep that code for a while for backward compatibility
     by = config.get_optional<std::string>("<xmlattr>.uid").get_value_or("");
     if(by.empty())
     {

--- a/SrcLib/core/fwServices/include/fwServices/SConfigController.hpp
+++ b/SrcLib/core/fwServices/include/fwServices/SConfigController.hpp
@@ -20,28 +20,31 @@ namespace fwServices
 {
 
 /**
- * @brief   To manage configuration file defines in xml extension.
+ * @brief   This service starts/stops a template configuration.
  *
- * This action works on a ::fwData::Composite. It action starts/stops a template configuration given by its identifier in this action configuration.
- *  - You can specified pattern to replace in the template configuration by the tag 'replace'.
- *  - You can specified pattern to replace by the uid of the object contained by the composite with the given key
- *  - The pattern GENERIC_UID is replaced by a generated unique identifier when the configuration is launch.
- *  This assure that the created object and services in the configuration have a unique uid even if this
- *  configuration is launch several times.
+ *  The parameters of the template configuration <param name="..." /> are filled according to the
+ *  <inout> and <parameter> tags. Using <inout> is especially useful to wait for deferred objects, but it is strongly
+ * recommended to use it to pass any object.
+ * Note that <in> is not supported. This would have no meaning, because we can't ensure the object won't be modified
+ * in the configuration. <out> is also not supported because if we assume that the target configuration produces the
+ * object, thus we would not get a valid id for the matching parameter.
  *
- * Example of this service configuration
+ * @section XML XML Configuration
+ *
  * @code{.xml}
-   <service impl="::fwServices::SConfigController" type="::fwServices::IController">
-       <config>
-           <appConfig id="IdOfConfig" >
-               <parameters>
-                   <parameter replace="SERIESDB" by="medicalData"  />
-                   <parameter replace="IMAGE" by="@values.image"  />
-               </parameters>
-           </appConfig>
-       </config>
-   </service>
+        <service type="::fwServices::SConfigController" >
+            <appConfig id="IdOfConfig" />
+            <inout key="object" uid="..." />
+            <parameter replace="channel" by="changeValueChannel"  />
+            <parameter replace="service" by="serviceUid" />
+        </service>
    @endcode
+ * @subsection In-Out In-Out:
+ * - \b object [::fwData::Object]: \b key specifies the name of the parameter in the target configuration and \b uid
+ * identifies the object whose uid is passed as value of the parameter.
+ * @subsection Configuration Configuration:
+ * - \b parameter: \b replace specifies the name of the parameter in the target configuration and \b by the value of
+ * this parameter. The variable GENERIC_UID can be used as unique identifier when the configuration is launched.
  */
 class FWSERVICES_CLASS_API SConfigController : public ::fwServices::IController
 {

--- a/SrcLib/core/fwServices/include/fwServices/SConfigController.hpp
+++ b/SrcLib/core/fwServices/include/fwServices/SConfigController.hpp
@@ -7,22 +7,20 @@
 #ifndef __FWSERVICES_SCONFIGCONTROLLER_HPP__
 #define __FWSERVICES_SCONFIGCONTROLLER_HPP__
 
-#include <fwTools/Failed.hpp>
+#include "fwServices/IController.hpp"
+#include "fwServices/config.hpp"
+#include "fwServices/helper/ConfigLauncher.hpp"
 
 #include <fwRuntime/ConfigurationElement.hpp>
 #include <fwRuntime/EConfigurationElement.hpp>
 
-#include "fwServices/helper/ConfigLauncher.hpp"
-#include "fwServices/config.hpp"
-#include "fwServices/IController.hpp"
+#include <fwTools/Failed.hpp>
 
 namespace fwServices
 {
 
 /**
- * @class   SConfigController
  * @brief   To manage configuration file defines in xml extension.
- * @date    2010-2013.
  *
  * This action works on a ::fwData::Composite. It action starts/stops a template configuration given by its identifier in this action configuration.
  *  - You can specified pattern to replace in the template configuration by the tag 'replace'.
@@ -96,12 +94,12 @@ protected:
     virtual void swapping();
 
     /// Overrides
-    virtual void info( std::ostream &_sstream );
+    virtual void info( std::ostream& _sstream );
 
 private:
 
     /// AppConfig manager
-    ::fwServices::helper::ConfigLauncher::sptr m_configLauncher;
+    ::fwServices::helper::ConfigLauncher::uptr m_configLauncher;
 
 };
 

--- a/SrcLib/core/fwServices/include/fwServices/helper/ConfigLauncher.hpp
+++ b/SrcLib/core/fwServices/include/fwServices/helper/ConfigLauncher.hpp
@@ -32,15 +32,12 @@ namespace helper
 /**
  * @brief   This class provides few methods to manage AppConfig (parsing, starting, stopping...).
  */
-class FWSERVICES_CLASS_API ConfigLauncher : public ::fwCore::BaseObject
+class FWSERVICES_CLASS_API ConfigLauncher
 {
 
 public:
 
-    fwCoreClassDefinitionsWithFactoryMacro( (ConfigLauncher)(::fwCore::BaseObject),
-                                            (()),
-                                            std::make_shared< ConfigLauncher > );
-
+    typedef std::unique_ptr<ConfigLauncher> uptr;
     typedef ::fwServices::registry::FieldAdaptorType FieldAdaptorType;
 
     /// Constructor. Do nothing.
@@ -56,17 +53,15 @@ public:
      * @code{.xml}
        <service>
            <config>
-                <appConfig id="Visu2DID" >
-                    <parameters>
-                        <parameter replace="SERIESDB" by="medicalData"  />
-                        <parameter replace="IMAGE" by="@values.image"  />
-                    </parameters>
-                </appConfig>
+                <appConfig id="Visu2DID" />
+                <parameter replace="SERIESDB" by="medicalData" />
+                <parameter replace="IMAGE" by="@values.image" />
             </config>
        </service>
         @endcode
      */
-    FWSERVICES_API virtual void parseConfig(const ::fwServices::IService::ConfigType& config);
+    FWSERVICES_API virtual void parseConfig(const ::fwServices::IService::ConfigType& config,
+                                            const ::fwServices::IService::sptr &service);
 
     /**
      * @brief Launch Appconfig

--- a/SrcLib/core/fwServices/include/fwServices/registry/AppConfig2.hpp
+++ b/SrcLib/core/fwServices/include/fwServices/registry/AppConfig2.hpp
@@ -21,6 +21,7 @@
 #include <fwTools/Object.hpp>
 
 #include <map>
+#include <unordered_set>
 
 namespace fwServices
 {
@@ -74,9 +75,9 @@ public:
                                     const std::string& group,
                                     const std::string& desc,
                                     const AppInfo::ParametersType& parameters,
-                                    ::fwRuntime::ConfigurationElement::csptr config,
-                                    const std::string bundleId,
-                                    const std::string bundleVersion);
+                                    const ::fwRuntime::ConfigurationElement::csptr& config,
+                                    const std::string& bundleId,
+                                    const std::string& bundleVersion);
 
     /**
      * @brief  Return the adapted config with the identifier configId.
@@ -103,7 +104,7 @@ public:
      * @brief Retrieves the bunble from the config id
      * @param configId the config identifier
      */
-    FWSERVICES_API std::shared_ptr< ::fwRuntime::Bundle > getBundle(const std::string& configId);
+    FWSERVICES_API std::shared_ptr< ::fwRuntime::Bundle > getBundle(const std::string& _configId);
 
     /**
      * @brief Return all configurations ( standard and template ) register in the registry.
@@ -144,16 +145,22 @@ protected:
 
 private:
 
+    typedef std::unordered_set< std::string > UidParameterReplaceType;
+
     /// Convert the composite into map <pattern, value>.
     FieldAdaptorType compositeToFieldAdaptor( ::fwData::Composite::csptr fieldAdaptors ) const;
 
+    static void collectUIDForParameterReplace(::fwRuntime::ConfigurationElement::csptr _cfgElem,
+                                   UidParameterReplaceType& replaceMap);
+
     /// Adapts the configuration : replace field thanks to field adaptors
-    ::fwRuntime::EConfigurationElement::sptr adaptConfig(::fwRuntime::ConfigurationElement::csptr _cfgElem,
-                                                         const FieldAdaptorType& fieldAdaptors,
-                                                         const std::string& autoPrefixId ) const;
+    static ::fwRuntime::EConfigurationElement::sptr adaptConfig(::fwRuntime::ConfigurationElement::csptr _cfgElem,
+                                                                const FieldAdaptorType& _fieldAdaptors,
+                                                                const UidParameterReplaceType& _uidParameterReplace,
+                                                                const std::string& _autoPrefixId );
 
     /// Adapts field thanks to field adaptors
-    std::string adaptField( const std::string& _str, const FieldAdaptorType& fieldAdaptors ) const;
+    static std::string adaptField(const std::string& _str, const FieldAdaptorType& _variablesMap );
 
     /// Used to protect the registry access.
     mutable ::fwCore::mt::ReadWriteMutex m_registryMutex;
@@ -166,6 +173,10 @@ private:
 
     /// The static identifier for mandatory parameters.
     static std::string s_mandatoryParameterIdentifier;
+
+    /// Associations of <tag id, generic-uid attribute>.
+    typedef std::multimap< std::string, std::string > UidDefinitionType;
+    static UidDefinitionType s_uidDefinitionDictionary;
 };
 
 } // namespace registry

--- a/SrcLib/core/fwServices/src/fwServices/IService.cpp
+++ b/SrcLib/core/fwServices/src/fwServices/IService.cpp
@@ -345,12 +345,10 @@ IService::SharedFutureType IService::update()
 {
     if( !m_associatedWorker || ::fwThread::getCurrentThreadId() == m_associatedWorker->getThreadId() )
     {
-        OSLM_ASSERT(
-            "INVOKING update WHILE STOPPED ("<<m_globalState<<") on this = " << this->getClassname(),
-            m_globalState == STARTED );
-        OSLM_ASSERT(
-            "INVOKING update WHILE NOT IDLE ("<<m_updatingState<<") on this = " << this->getClassname(),
-            m_updatingState == NOTUPDATING );
+        OSLM_ASSERT("INVOKING update WHILE STOPPED ("<<m_globalState<<") on service '" << this->getID() <<
+                    "' of type '" << this->getClassname() << "'", m_globalState == STARTED );
+        OSLM_ASSERT("INVOKING update WHILE NOT IDLE ("<<m_updatingState<<") on service '" << this->getID() <<
+                    "' of type '" << this->getClassname() << "'", m_updatingState == NOTUPDATING );
 
         PackagedTaskType task( ::boost::bind(&IService::updating, this) );
         UniqueFutureType ufuture = task.get_future();

--- a/SrcLib/core/fwServices/src/fwServices/SConfigController.cpp
+++ b/SrcLib/core/fwServices/src/fwServices/SConfigController.cpp
@@ -4,26 +4,24 @@
  * published by the Free Software Foundation.
  * ****** END LICENSE BLOCK ****** */
 
+#include "fwServices/SConfigController.hpp"
+
 #include <fwServices/macros.hpp>
 
-#include <fwTools/fwID.hpp>
-
-#include <fwRuntime/Convert.hpp>
-
-#include "fwServices/SConfigController.hpp"
+#include <boost/make_unique.hpp>
 
 namespace fwServices
 {
 
 //------------------------------------------------------------------------------
 
-fwServicesRegisterMacro( ::fwServices::IController, ::fwServices::SConfigController, ::fwData::Object );
+fwServicesRegisterMacro( ::fwServices::IController, ::fwServices::SConfigController );
 
 //------------------------------------------------------------------------------
 
 SConfigController::SConfigController() noexcept
 {
-    m_configLauncher = ::fwServices::helper::ConfigLauncher::New();
+    m_configLauncher = ::boost::make_unique< ::fwServices::helper::ConfigLauncher>();
 }
 
 //------------------------------------------------------------------------------
@@ -58,69 +56,7 @@ void SConfigController::swapping()
 
 void SConfigController::configuring()
 {
-    if(this->isVersion2())
-    {
-        typedef ::fwRuntime::ConfigurationElement::sptr ConfigType;
-        typedef ::fwRuntime::EConfigurationElement::sptr EditableConfigType;
-
-        ConfigType cfg = this->getConfiguration();
-
-        ConfigType appCfg = cfg->findConfigurationElement("appConfig");
-        SLM_ASSERT("Missing 'appConfig' tag.", appCfg);
-        std::string appCfgId = appCfg->getAttributeValue("id");
-
-        EditableConfigType srvCfg    = ::fwRuntime::EConfigurationElement::New( "service" );
-        EditableConfigType newCfg    = srvCfg->addConfigurationElement("config");
-        EditableConfigType newAppCfg = newCfg->addConfigurationElement("appConfig");
-        newAppCfg->setAttributeValue("id", appCfgId);
-
-        EditableConfigType newParamsCfg = newAppCfg->addConfigurationElement("parameters");
-
-        const std::vector< ConfigType > inoutsCfg = cfg->find("inout");
-        for (const auto& inoutCfg : inoutsCfg)
-        {
-            std::string key = inoutCfg->getAttributeValue("key");
-            SLM_ASSERT("[" + appCfgId + "] Missing 'key' tag.", !key.empty());
-
-            std::string uid = inoutCfg->getAttributeValue("uid");
-            SLM_ASSERT("[" + appCfgId + "] Missing 'uid' tag.", !uid.empty());
-
-            EditableConfigType newParamCfg = newParamsCfg->addConfigurationElement("parameter");
-            newParamCfg->setAttributeValue("replace", key);
-
-            auto obj = this->getInOut< ::fwData::Object>(key);
-            newParamCfg->setAttributeValue("uid", obj->getID());
-        }
-
-        const std::vector< ConfigType > paramsCfg = cfg->find("parameter");
-        for (const auto& paramCfg : paramsCfg)
-        {
-            std::string replace = paramCfg->getAttributeValue("replace");
-            SLM_ASSERT("[" + appCfgId + "] Missing 'replace' tag.", !replace.empty());
-
-            EditableConfigType newParamCfg = newParamsCfg->addConfigurationElement("parameter");
-            newParamCfg->setAttributeValue("replace", replace);
-
-            std::string uid = paramCfg->getAttributeValue("uid");
-            if(!uid.empty())
-            {
-                newParamCfg->setAttributeValue("uid", uid);
-            }
-            else
-            {
-                SLM_ASSERT("[" + appCfgId + "] Missing 'uid' or 'by' tag.", paramCfg->hasAttribute("by"));
-                std::string by = paramCfg->getAttributeValue("by");
-                // 'by' can be empty
-                newParamCfg->setAttributeValue("by", by);
-            }
-        }
-
-        m_configLauncher->parseConfig(::fwRuntime::Convert::toPropertyTree(srvCfg));
-    }
-    else
-    {
-        m_configLauncher->parseConfig(this->getConfigTree());
-    }
+    m_configLauncher->parseConfig(this->getConfigTree(), this->getSptr());
 }
 
 //------------------------------------------------------------------------------
@@ -131,7 +67,7 @@ void SConfigController::updating()
 
 //------------------------------------------------------------------------------
 
-void SConfigController::info( std::ostream &_sstream )
+void SConfigController::info( std::ostream& _sstream )
 {
 }
 

--- a/SrcLib/core/fwServices/src/fwServices/helper/ConfigLauncher.cpp
+++ b/SrcLib/core/fwServices/src/fwServices/helper/ConfigLauncher.cpp
@@ -15,14 +15,18 @@
 
 #include "fwServices/helper/ConfigLauncher.hpp"
 
+#include <boost/property_tree/xml_parser.hpp>
+
 namespace fwServices
 {
 namespace helper
 {
 
 //------------------------------------------------------------------------------
+
 const std::string ConfigLauncher::s_SELF_KEY        = "self";
 const std::string ConfigLauncher::s_GENERIC_UID_KEY = "GENERIC_UID";
+
 //------------------------------------------------------------------------------
 
 ConfigLauncher::ConfigLauncher() : m_configIsRunning(false)
@@ -37,22 +41,78 @@ ConfigLauncher::~ConfigLauncher()
 
 //------------------------------------------------------------------------------
 
-void ConfigLauncher::parseConfig(const ::fwServices::IService::ConfigType& config)
+void ConfigLauncher::parseConfig(const ::fwServices::IService::ConfigType& config,
+                                 const ::fwServices::IService::sptr& service)
 {
-    if(config.get_child("service").count("config") > 0)
-    {
-        SLM_ASSERT("There must be one (and only one) <config/> element.",
-                   config.get_child("service").count("config") == 1 );
-        const ::fwServices::IService::ConfigType srvconfig = config.get_child("service");
-        const ::fwServices::IService::ConfigType& config   = srvconfig.get_child("config");
+    ::fwServices::IService::ConfigType srvCfg;
+    const ::fwServices::IService::ConfigType* curConfig = &config;
 
-        if(config.count("appConfig") == 1 )
+    if(::fwServices::IService::isVersion2())
+    {
+        const ::fwServices::IService::ConfigType& oldConfig = config.get_child("service");
+        SLM_ASSERT("There must be only one <appConfig/> element.", oldConfig.count("appConfig") == 1 );
+
+        const ::fwServices::IService::ConfigType& appConfig = oldConfig.get_child("appConfig");
+        const std::string appCfgId                          = appConfig.get<std::string>("<xmlattr>.id");
+
+        srvCfg.add("service.config.appConfig.<xmlattr>.id", appCfgId);
+        ::fwServices::IService::ConfigType& newCfg = srvCfg.get_child("service.config.appConfig");
+        curConfig = &srvCfg;
+
+        auto inoutsCfg = oldConfig.equal_range("inout");
+        for (auto itCfg = inoutsCfg.first; itCfg != inoutsCfg.second; ++itCfg)
         {
-            const ::fwServices::IService::ConfigType& appConfig = config.get_child("appConfig");
-            m_appConfig = ::fwActivities::registry::ActivityAppConfig(appConfig);
+            ::fwServices::IService::ConfigType parameterCfg;
+
+            const std::string key = itCfg->second.get<std::string>("<xmlattr>.key");
+            SLM_ASSERT("[" + appCfgId + "] Missing 'key' tag.", !key.empty());
+
+            const std::string uid = itCfg->second.get<std::string>("<xmlattr>.uid");
+            SLM_ASSERT("[" + appCfgId + "] Missing 'uid' tag.", !uid.empty());
+
+            parameterCfg.add("<xmlattr>.replace", key);
+
+            auto obj = service->getInOut< ::fwData::Object>(key);
+            parameterCfg.add("<xmlattr>.uid", obj->getID());
+
+            newCfg.add_child("parameters.parameter", parameterCfg);
         }
-        OSLM_ASSERT("At most 1 <appConfig> tag is allowed", config.count("appConfig") < 2);
+
+        // @deprecated This is no longer necessary to use "uid" to get the prefix replacement, since
+        // this is now done in AppConfig2. However we keep that code for a while for backward compatibility
+        auto paramsCfg = oldConfig.equal_range("parameter");
+        for (auto itCfg = paramsCfg.first; itCfg != paramsCfg.second; ++itCfg)
+        {
+            ::fwServices::IService::ConfigType parameterCfg;
+
+            const std::string replace = itCfg->second.get<std::string>("<xmlattr>.replace");
+            SLM_ASSERT("[" + appCfgId + "] Missing 'replace' tag.", !replace.empty());
+
+            parameterCfg.add("<xmlattr>.replace", replace);
+
+            if(itCfg->second.get_child("<xmlattr>").count("uid") == 1)
+            {
+                const std::string uid = itCfg->second.get<std::string>("<xmlattr>.uid");
+                parameterCfg.add("<xmlattr>.uid", uid);
+            }
+            else
+            {
+                const std::string by = itCfg->second.get<std::string>("<xmlattr>.by");
+                parameterCfg.add("<xmlattr>.by", by);
+            }
+
+            newCfg.add_child("parameters.parameter", parameterCfg);
+        }
     }
+
+    SLM_ASSERT("There must be only one <config/> element.", curConfig->get_child("service").count("config") == 1 );
+
+    const ::fwServices::IService::ConfigType& srvconfig = curConfig->get_child("service.config");
+
+    SLM_ASSERT("There must be only one <appConfig/> element.", srvconfig.count("appConfig") == 1 );
+
+    const ::fwServices::IService::ConfigType& appConfig = srvconfig.get_child("appConfig");
+    m_appConfig = ::fwActivities::registry::ActivityAppConfig(appConfig);
 }
 
 //------------------------------------------------------------------------------

--- a/SrcLib/core/fwServices/src/fwServices/registry/AppConfig2.cpp
+++ b/SrcLib/core/fwServices/src/fwServices/registry/AppConfig2.cpp
@@ -396,7 +396,9 @@ std::string AppConfig2::adaptField( const std::string& _str, const FieldAdaptorT
     if(!_str.empty())
     {
         // Discriminate first variable expressions only, looking through all keys of the replace map is not for free
-        if ( ::boost::regex_match(_str, s_isVariable ) )
+        // However we look inside the whole string instead of only at the beginning because we want  to replace "inner"
+        // variables as well, i.e. not only ${uid} but also uid${suffix}
+        if ( ::boost::regex_search(_str, s_isVariable ) )
         {
             // Iterate over all variables
             for(const auto& fieldAdaptor : _variablesMap )

--- a/SrcLib/core/fwServices/src/fwServices/registry/AppConfig2.cpp
+++ b/SrcLib/core/fwServices/src/fwServices/registry/AppConfig2.cpp
@@ -296,7 +296,7 @@ void AppConfig2::collectUIDForParameterReplace(::fwRuntime::ConfigurationElement
 
         for (auto it = range.first; it != range.second; ++it)
         {
-            if(it->second == attribute.first && !::boost::regex_match(attribute.first, s_isVariable ) )
+            if(it->second == attribute.first && !::boost::regex_match(attribute.second, s_isVariable ) )
             {
                 _replaceMap.insert(attribute.second);
             }

--- a/SrcLib/core/fwServices/test/tu/include/AppConfig2Test.hpp
+++ b/SrcLib/core/fwServices/test/tu/include/AppConfig2Test.hpp
@@ -30,6 +30,7 @@ CPPUNIT_TEST( connectionTest );
 CPPUNIT_TEST( optionalKeyTest );
 CPPUNIT_TEST( keyGroupTest );
 CPPUNIT_TEST( concurentAccessToAppConfig2Test );
+CPPUNIT_TEST( parameterReplaceTest );
 CPPUNIT_TEST_SUITE_END();
 
 
@@ -45,6 +46,7 @@ public:
     void optionalKeyTest();
     void keyGroupTest();
     void concurentAccessToAppConfig2Test();
+    void parameterReplaceTest();
 
 private:
     ::fwRuntime::ConfigurationElement::sptr buildConfig();
@@ -54,10 +56,12 @@ private:
     ::fwRuntime::ConfigurationElement::sptr buildConnectionConfig();
     ::fwRuntime::ConfigurationElement::sptr buildOptionalKeyConfig();
     ::fwRuntime::ConfigurationElement::sptr buildKeyGroupConfig();
+    ::fwRuntime::ConfigurationElement::sptr buildParameterReplaceConfig();
 
 
     ::fwServices::AppConfigManager2::sptr launchAppConfigMgr(const std::string &name,
-                                                             const ::fwRuntime::ConfigurationElement::csptr& config);
+                                                             const ::fwRuntime::ConfigurationElement::csptr& config,
+                                                             bool autoPrefix = false);
 
     ::fwServices::AppConfigManager2::sptr m_appConfigMgr;
 };

--- a/SrcLib/core/fwServices/test/tu/src/AppConfig2Test.cpp
+++ b/SrcLib/core/fwServices/test/tu/src/AppConfig2Test.cpp
@@ -1150,8 +1150,16 @@ void AppConfig2Test::parameterReplaceTest()
     ::fwRuntime::ConfigurationElement::csptr config = this->buildParameterReplaceConfig();
     m_appConfigMgr                                  = this->launchAppConfigMgr("", config, true);
 
-    fwTools::Object::sptr gnsrv1 = ::fwTools::fwID::getObject("AppConfig2Manager_1_TestService2Uid");
-    auto srv1                    = ::fwServices::ut::TestService::dynamicCast(gnsrv1);
+    unsigned int i = 0;
+    fwTools::Object::sptr gnsrv1;
+
+    // Not really elegant, but we have to "guess" how it is replaced
+    while (gnsrv1 == nullptr && i++ < 200)
+    {
+        gnsrv1 = ::fwTools::fwID::getObject("AppConfig2Manager_" + std::to_string(i) + "_TestService2Uid");
+    }
+
+    auto srv1 = ::fwServices::ut::TestService::dynamicCast(gnsrv1);
     CPPUNIT_ASSERT(srv1 != nullptr);
 
     auto adaptedConfig = srv1->getConfiguration();
@@ -1162,16 +1170,16 @@ void AppConfig2Test::parameterReplaceTest()
     std::string replaceBy;
 
     replaceBy = paramsCfg[0]->getAttributeValue("by");
-    CPPUNIT_ASSERT_EQUAL(std::string("AppConfig2Manager_1_data2Id"), replaceBy);
+    CPPUNIT_ASSERT_EQUAL(std::string("AppConfig2Manager_" + std::to_string(i) + "_data2Id"), replaceBy);
 
     replaceBy = paramsCfg[1]->getAttributeValue("by");
     CPPUNIT_ASSERT_EQUAL(std::string("name"), replaceBy);
 
     replaceBy = paramsCfg[2]->getAttributeValue("by");
-    CPPUNIT_ASSERT_EQUAL(std::string("AppConfig2Manager_1_Channel No5"), replaceBy);
+    CPPUNIT_ASSERT_EQUAL(std::string("AppConfig2Manager_" + std::to_string(i) + "_Channel No5"), replaceBy);
 
     replaceBy = paramsCfg[3]->getAttributeValue("by");
-    CPPUNIT_ASSERT_EQUAL(std::string("AppConfig2Manager_1_view1"), replaceBy);
+    CPPUNIT_ASSERT_EQUAL(std::string("AppConfig2Manager_" + std::to_string(i) + "_view1"), replaceBy);
 }
 
 //------------------------------------------------------------------------------

--- a/SrcLib/core/fwServices/test/tu/src/AppConfig2Test.cpp
+++ b/SrcLib/core/fwServices/test/tu/src/AppConfig2Test.cpp
@@ -130,7 +130,8 @@ void AppConfig2Test::parametersConfigTest()
 
 ::fwServices::AppConfigManager2::sptr AppConfig2Test::launchAppConfigMgr(
     const std::string& name,
-    const ::fwRuntime::ConfigurationElement::csptr& config)
+    const ::fwRuntime::ConfigurationElement::csptr& config,
+    bool autoPrefix)
 {
     const std::string configId(name);
     const std::string group("parametersGroup");
@@ -143,7 +144,7 @@ void AppConfig2Test::parametersConfigTest()
     currentAppConfig->addAppInfo(configId, group, desc, parameters, config, bundleId, bundleVersion);
 
     auto appConfigMgr = ::fwServices::AppConfigManager2::New();
-    appConfigMgr->setIsUnitTest(true);
+    appConfigMgr->setIsUnitTest(!autoPrefix);
 
     const ::fwServices::registry::FieldAdaptorType fields;
     appConfigMgr->setConfig( configId, fields );
@@ -1144,6 +1145,37 @@ void AppConfig2Test::concurentAccessToAppConfig2Test()
 
 //------------------------------------------------------------------------------
 
+void AppConfig2Test::parameterReplaceTest()
+{
+    ::fwRuntime::ConfigurationElement::csptr config = this->buildParameterReplaceConfig();
+    m_appConfigMgr                                  = this->launchAppConfigMgr("", config, true);
+
+    fwTools::Object::sptr gnsrv1 = ::fwTools::fwID::getObject("AppConfig2Manager_1_TestService2Uid");
+    auto srv1                    = ::fwServices::ut::TestService::dynamicCast(gnsrv1);
+    CPPUNIT_ASSERT(srv1 != nullptr);
+
+    auto adaptedConfig = srv1->getConfiguration();
+
+    typedef ::fwRuntime::ConfigurationElement::sptr ConfigType;
+    const std::vector< ConfigType > paramsCfg = adaptedConfig->find("parameter");
+
+    std::string replaceBy;
+
+    replaceBy = paramsCfg[0]->getAttributeValue("by");
+    CPPUNIT_ASSERT_EQUAL(std::string("AppConfig2Manager_1_data2Id"), replaceBy);
+
+    replaceBy = paramsCfg[1]->getAttributeValue("by");
+    CPPUNIT_ASSERT_EQUAL(std::string("name"), replaceBy);
+
+    replaceBy = paramsCfg[2]->getAttributeValue("by");
+    CPPUNIT_ASSERT_EQUAL(std::string("AppConfig2Manager_1_Channel No5"), replaceBy);
+
+    replaceBy = paramsCfg[3]->getAttributeValue("by");
+    CPPUNIT_ASSERT_EQUAL(std::string("AppConfig2Manager_1_view1"), replaceBy);
+}
+
+//------------------------------------------------------------------------------
+
 ::fwRuntime::ConfigurationElement::sptr AppConfig2Test::buildParametersConfig()
 {
     // Configuration on fwTools::Object which uid is objectUUID
@@ -1717,6 +1749,77 @@ fwRuntime::ConfigurationElement::sptr AppConfig2Test::buildKeyGroupConfig()
 
     // Start method from object's services
     cfg->addConfigurationElement("start")->setAttributeValue( "uid", "SGenerateData" );
+    cfg->addConfigurationElement("start")->setAttributeValue( "uid", "TestService1Uid" );
+    cfg->addConfigurationElement("start")->setAttributeValue( "uid", "TestService2Uid" );
+
+    return cfg;
+}
+
+//------------------------------------------------------------------------------
+
+fwRuntime::ConfigurationElement::sptr AppConfig2Test::buildParameterReplaceConfig()
+{
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > cfg ( new ::fwRuntime::EConfigurationElement("config"));
+
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > objCfg = cfg->addConfigurationElement("object");
+    objCfg->setAttributeValue( "uid", "data1Id");
+    objCfg->setAttributeValue( "type", "::fwData::String");
+
+    objCfg = cfg->addConfigurationElement("object");
+    objCfg->setAttributeValue( "uid", "data2Id");
+    objCfg->setAttributeValue( "type", "::fwData::Boolean");
+
+    objCfg = cfg->addConfigurationElement("object");
+    objCfg->setAttributeValue( "uid", "data3Id");
+    objCfg->setAttributeValue( "type", "::fwData::Image");
+
+    // Service #1
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > service1 = cfg->addConfigurationElement("service");
+    service1->setAttributeValue( "uid", "TestService1Uid" );
+    service1->setAttributeValue("type", "::fwServices::ut::TestServiceImplementation" );
+
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > dataService1_1 = service1->addConfigurationElement("in");
+    dataService1_1->setAttributeValue( "key", "data1" );
+    dataService1_1->setAttributeValue( "uid", "data1Id" );
+    dataService1_1->setAttributeValue( "autoConnect", "yes" );
+
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > configService1 = service1->addConfigurationElement("view");
+    configService1->setAttributeValue( "wid", "view1" );
+
+    // Service #2
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > service2 = cfg->addConfigurationElement("service");
+    service2->setAttributeValue( "uid", "TestService2Uid" );
+    service2->setAttributeValue("type", "::fwServices::ut::TestServiceImplementation" );
+
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > dataService2_1 =
+        service2->addConfigurationElement("parameter");
+    dataService2_1->setAttributeValue( "replace", "data2" );
+    dataService2_1->setAttributeValue( "by", "data2Id" );
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > dataService2_2 =
+        service2->addConfigurationElement("parameter");
+    dataService2_2->setAttributeValue( "replace", "patient" );
+    dataService2_2->setAttributeValue( "by", "name" );
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > dataService2_3 =
+        service2->addConfigurationElement("parameter");
+    dataService2_3->setAttributeValue( "replace", "channel1" );
+    dataService2_3->setAttributeValue( "by", "Channel No5" );
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > dataService2_4 =
+        service2->addConfigurationElement("parameter");
+    dataService2_4->setAttributeValue( "replace", "WID_PARENT" );
+    dataService2_4->setAttributeValue( "by", "view1" );
+
+    // Connections
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > connect1 = cfg->addConfigurationElement("connect");
+    connect1->setAttributeValue( "channel", "disneyChannel" );
+    connect1->addConfigurationElement("signal")->setValue( "data1Id/modified" );
+    connect1->addConfigurationElement("slot")->setValue( "TestService2Uid/update" );
+
+    std::shared_ptr< ::fwRuntime::EConfigurationElement > connect2 = cfg->addConfigurationElement("connect");
+    connect2->setAttributeValue( "channel", "Channel No5" );
+    connect2->addConfigurationElement("signal")->setValue( "data2Id/modified" );
+    connect2->addConfigurationElement("slot")->setValue( "TestService2Uid/update" );
+
+    // Start method from object's services
     cfg->addConfigurationElement("start")->setAttributeValue( "uid", "TestService1Uid" );
     cfg->addConfigurationElement("start")->setAttributeValue( "uid", "TestService2Uid" );
 


### PR DESCRIPTION
We can now use "by" each time, like in former appXml. The historical "GENERIC_UID" substitution is performed in AppConfig2 when parsing the configuration. I build a dictionnary of potential targets for a future replacement, and then I simply lookup when I parse a "by" attribute of a "parameter" tag. This is not very elegant, but I think removing this attribute is more important. We can rework the implementation later but in the current state, the choice between "uid" and "by" is really misleading and must be removed asap. Note that for backwards compatibility, it is still allowed to specify "uid", so people can migrate when they want.
The code that translates the appXml2 configuration of the launcher has been merged from SConfigController and SConfigLauncher into ConfigLauncher. A unit test has been added to verify this.